### PR TITLE
The parent node might have been visited more than the children, so need to adjust probability total.

### DIFF
--- a/montecarlo/montecarlo.py
+++ b/montecarlo/montecarlo.py
@@ -23,7 +23,7 @@ class MonteCarlo:
 	def make_exploratory_choice(self):
 		children_visits = map(lambda child: child.visits, self.root_node.children)
 		children_visit_probabilities = [visit / self.root_node.visits for visit in children_visits]
-		random_probability = random.uniform(0, 1)
+		random_probability = random.uniform(0, sum(children_visit_probabilities))
 		probabilities_already_counted = 0.
 
 		for i, probability in enumerate(children_visit_probabilities):


### PR DESCRIPTION
This actually happens in the policy value test.
There the probabilities sum to 0.98.